### PR TITLE
A variant that assigns each thread a logical core seems not to segfault

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-seq 1 $1 | xargs -n 1 -P $1 ./run1.sh "$2"
+seq 0 $((${1}-1)) | xargs -n 1 -P $1 -I CPU taskset -c CPU ./run1.sh $2
 


### PR DESCRIPTION
Just a contribution to further debug this issue.
I observed that when the processes remain "isolated" in their respective cache domains there seem to be no segfaults.